### PR TITLE
Bump ccxt from 1.21.89 to 1.22.36 in /exporter

### DIFF
--- a/exporter/requirements.txt
+++ b/exporter/requirements.txt
@@ -1,4 +1,4 @@
-ccxt==1.21.89
+ccxt==1.22.36
 prometheus_client==0.7.1
 requests==2.22.0
 pygelf==0.3.6


### PR DESCRIPTION
Bump [ccxt](https://github.com/ccxt/ccxt) from 1.21.89 to 1.22.36
* [Commits](https://github.com/ccxt/ccxt/compare/1.21.89...1.22.36)